### PR TITLE
SUP-1811 - Translation of “Inspiration” from ting_recommender module.

### DIFF
--- a/js/ting_recommender.js
+++ b/js/ting_recommender.js
@@ -7,6 +7,6 @@
 
 window.addEventListener('load', function () {
   let container = document.querySelector('#ting-recommender');
-  let asd = container.getElementsByTagName('h2');
-  asd[0].textContent = Drupal.t('Inspiration');
+  let heading = container.getElementsByTagName('h2');
+  heading[0].textContent = Drupal.t('Inspiration');
 });

--- a/js/ting_recommender.js
+++ b/js/ting_recommender.js
@@ -1,0 +1,12 @@
+/**
+ * @file
+ * JS logic used in ting_recommender.
+ */
+
+"use strict";
+
+window.addEventListener('load', function () {
+  let container = document.querySelector('#ting-recommender');
+  let asd = container.getElementsByTagName('h2');
+  asd[0].textContent = Drupal.t('Inspiration');
+});

--- a/plugins/content_types/recommender.inc
+++ b/plugins/content_types/recommender.inc
@@ -23,8 +23,7 @@ function ting_recommender_content_type_render($subtype, $conf, $panel_args, $con
   drupal_add_js('https://cdn.bibspire.dk/ddbcms.js', 'external');
 
   // Set block content.
-  $block->content = '<div id="ting-recommender"></div>';
+  $block->content['#markup'] = '<div id="ting-recommender"></div>';
+  $block->content['#attached']['js'][] = drupal_get_path('module', 'ting_recommender') . '/js/ting_recommender.js';
   return $block;
 }
-
-


### PR DESCRIPTION
Added possibility to translate and show translated "Inspiration" heading from ting_recommender module.

The main problem consists in fact that "Inspiration" heading is a part of HTML markup rendered by `https://cdn.bibspire.dk/ddbcms.js` script, so it was hard to fetch the moment when markup is already loaded and it can be changed.

After deployment:
1. Clear cache
2. Visit any page which have ting_recommender pane (any item page)
2. Go to `/admin/config/regional/translate/translate`, search for "Inspiration" string and translate this.